### PR TITLE
add need and iframe fields

### DIFF
--- a/generateLayers.js
+++ b/generateLayers.js
@@ -19,6 +19,7 @@ const tileSize = 32;
 // Define row properties that we want to fill 
 const areaWidth = 3;
 const areaHeight = 1;
+const areaEdgeMargin = 4;
 
 const tablesRow = 5;
 
@@ -111,6 +112,7 @@ function populateCategory(category, rowStarts, nextX, nextY) {
         var resourceUrl = resources[category][i].url;
         var resourceType = resources[category][i].type;
         var resourceNeed = resources[category][i].need;
+        var resourceIframe = resources[category][i].iframe;
 
         // Display warning & set type/need to "other" to catch typos or unsupported types/needs
         if (!resourceTypes.includes(resourceType)) {
@@ -125,7 +127,11 @@ function populateCategory(category, rowStarts, nextX, nextY) {
         // console.log('Processing resource: ' + resourceName);
 
         // Define trigger message that appears as players walk on each website object area
-        var triggerMessage = " ______________________________  Press SPACE to view website";
+        var triggerPrompt = "👓 Press SPACE to view website";
+        if (!resourceIframe) {
+            triggerPrompt = "🚪 Press SPACE to open link in new tab"
+        }
+        var triggerMessage = " ____________________________ " + triggerPrompt;
         if (resourceDesc) {
             triggerMessage = resourceName + ": " + resourceDesc + triggerMessage;
         } else {
@@ -167,20 +173,25 @@ function populateCategory(category, rowStarts, nextX, nextY) {
         // ADD NEW OBJECT TO THE OBJECT LAYER
         // Calculate coordinates of each website object area and add to the objects layer
         // Note that area y coordinates are different depending on area type ("below" | "above")
-        areaX = nextX * tileSize;
+        areaX = (nextX * tileSize) + areaEdgeMargin;
         if (rowType === "below") {
             areaY = (nextY + 1) * tileSize;
         } else if (rowType === "above") {
-            areaY = (nextY - areaHeight) * tileSize;
+            areaY = ((nextY - areaHeight) * tileSize) + areaEdgeMargin;
         }
+        var urlOpenType = "openWebsite";
+        if (!resourceIframe) {
+            urlOpenType = "openTab";
+        }
+        // Width & height are smaller due to margins on left, right and bottom/top
         areaNew = {
-            "width": areaWidth * tileSize,
-            "height": areaHeight * tileSize,
+            "width": (areaWidth * tileSize) - (2 * areaEdgeMargin),
+            "height": (areaHeight * tileSize) - areaEdgeMargin,
             "id":areaID,
             "name":resourceName,
             "properties":[
                     {
-                    "name":"openWebsite",
+                    "name":urlOpenType,
                     "type":"string",
                     "value":resourceUrl
                     },

--- a/generateLayers.js
+++ b/generateLayers.js
@@ -5,7 +5,7 @@ const rows = require('./rows.json');
 // Map properties, don't forget to change if map changes!
 const mapFile = "../RespTechLibrary/library.json";
 // Hint: use a test map first when making big changes to avoid corrupting the main mapFile
-const outputMapFile = "../RespTechLibrary/libraryTEST.json"; // mapFile; // 
+const outputMapFile = mapFile; // "../RespTechLibrary/libraryTEST.json"; 
 const outputObjectLayer = 'resourcesAreas';
 const outputTileLayer = 'resourcesTiles';
 

--- a/resources.json
+++ b/resources.json
@@ -131,117 +131,136 @@
       "url": "https://www.scu.edu/ethics-in-technology-practice/ethical-toolkit/",
       "description": "a toolkit by the Markkula Center for Applied Ethics ",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": false
     },
     {
       "name": "A Framework for More Ethical Innovation by Substantial",
       "url": "https://substantial.com/insights/ethical-innovation-framework",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Consequence Scanning Agile Kit",
       "url": "https://www.tech-transformed.com/product-development/",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Data Ethics Canvas by Open Data Institute",
       "url": "https://theodi.org/article/the-data-ethics-canvas-2021/",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Envisioning Cards",
       "url": "http://www.envisioningcards.com",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": false
     },
     {
       "name": "Ethical Licenses for Open Source Software",
       "url": "https://ethicalsource.dev/licenses/",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Ethics for Designers",
       "url": "https://www.ethicsfordesigners.com",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Privacy by Design",
       "url": "https://iapp.org/media/pdf/resource_center/pbd_implement_7found_principles.pdf",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": false
     },
     {
       "name": "Responsible tech playbook by Thoughtworks",
       "url": "https://www.thoughtworks.com/about-us/social-change/responsible-tech-playbook",
       "type": "tool",
-      "need": "observation"
+      "need": "observation",
+      "iframe": false
     },
     {
       "name": "Spotify's Ethics Assessment Worksheet",
       "url": "https://spoti.fi/Ethicsassessment",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Values in Computing",
       "url": "http://www.valuesincomputing.org",
       "type": "website",
-      "need": "observation"
+      "need": "observation",
+      "iframe": false
     },
     {
       "name": "Tethix Directory of Ethics Tools and Techniques",
       "url": "https://tethix.co/ethics-tools-directory/",
       "type": "website",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "The Ethics and Inclusion Framework",
       "url": "https://patriciagestoso.com/ethics-and-inclusion-framework/",
       "type": "tool",
-      "need": "practice"
+      "need": "practice",
+      "iframe": true
     },
     {
       "name": "Value Sensitive Design Research Lab",
       "url": "https://vsdesign.org/toolkits/",
       "type": "website",
-      "need": "observation"
+      "need": "observation",
+      "iframe": false
     },
     {
       "name": "Atlas of AI: Power, Politics, and the Planetary Costs of Artificial Intelligence",
       "url": "https://katecrawford.net/",
       "type": "book",
-      "need": "challenge"
+      "need": "challenge",
+      "iframe": true
     },
     {
       "name": "Ghost Work: How to Stop Silicon Valley from Building a New Global Underclass",
       "url": "https://ghostwork.info/",
       "type": "book",
-      "need": "challenge"
+      "need": "challenge",
+      "iframe": true
     },
     {
       "name": "Ruined by Design: A design ethics and activism book",
       "url": "https://www.ruinedby.design",
       "type": "book",
-      "need": "challenge"
+      "need": "challenge",
+      "iframe": true
     },
     {
       "name": "All Tech Is Human",
       "url": "https://alltechishuman.org/",
       "description": "is a non-profit focused on building the responsible tech pipeline.",
       "type": "org",
-      "need": "community"
+      "need": "community",
+      "iframe": true
     },
     {
       "name": "Ethical Design Network",
       "url": "https://ethicaldesignnetwork.com/",
       "description": "is a community for people interested in ethical design.",
       "type": "org",
-      "need": "community"
+      "need": "community",
+      "iframe": true
     }
   ], 
   "sustainability": [

--- a/resources.json
+++ b/resources.json
@@ -130,99 +130,118 @@
       "name": "An Ethical Toolkit for Engineering/Design Practice",
       "url": "https://www.scu.edu/ethics-in-technology-practice/ethical-toolkit/",
       "description": "a toolkit by the Markkula Center for Applied Ethics ",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "A Framework for More Ethical Innovation by Substantial",
       "url": "https://substantial.com/insights/ethical-innovation-framework",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Consequence Scanning Agile Kit",
       "url": "https://www.tech-transformed.com/product-development/",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Data Ethics Canvas by Open Data Institute",
       "url": "https://theodi.org/article/the-data-ethics-canvas-2021/",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Envisioning Cards",
       "url": "http://www.envisioningcards.com",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Ethical Licenses for Open Source Software",
       "url": "https://ethicalsource.dev/licenses/",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Ethics for Designers",
       "url": "https://www.ethicsfordesigners.com",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Privacy by Design",
       "url": "https://iapp.org/media/pdf/resource_center/pbd_implement_7found_principles.pdf",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Responsible tech playbook by Thoughtworks",
       "url": "https://www.thoughtworks.com/about-us/social-change/responsible-tech-playbook",
-      "type": "tool"
+      "type": "tool",
+      "need": "observation"
     },
     {
       "name": "Spotify's Ethics Assessment Worksheet",
       "url": "https://spoti.fi/Ethicsassessment",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Values in Computing",
       "url": "http://www.valuesincomputing.org",
-      "type": "website"
+      "type": "website",
+      "need": "observation"
     },
     {
       "name": "Tethix Directory of Ethics Tools and Techniques",
       "url": "https://tethix.co/ethics-tools-directory/",
-      "type": "website"
+      "type": "website",
+      "need": "practice"
     },
     {
       "name": "The Ethics and Inclusion Framework",
       "url": "https://patriciagestoso.com/ethics-and-inclusion-framework/",
-      "type": "tool"
+      "type": "tool",
+      "need": "practice"
     },
     {
       "name": "Value Sensitive Design Research Lab",
       "url": "https://vsdesign.org/toolkits/",
-      "type": "website"
+      "type": "website",
+      "need": "observation"
     },
     {
       "name": "Atlas of AI: Power, Politics, and the Planetary Costs of Artificial Intelligence",
       "url": "https://katecrawford.net/",
-      "type": "book"
+      "type": "book",
+      "need": "challenge"
     },
     {
       "name": "Ghost Work: How to Stop Silicon Valley from Building a New Global Underclass",
       "url": "https://ghostwork.info/",
-      "type": "book"
+      "type": "book",
+      "need": "challenge"
     },
     {
       "name": "Ruined by Design: A design ethics and activism book",
       "url": "https://www.ruinedby.design",
-      "type": "book"
+      "type": "book",
+      "need": "challenge"
     },
     {
       "name": "All Tech Is Human",
       "url": "https://alltechishuman.org/",
       "description": "is a non-profit focused on building the responsible tech pipeline.",
-      "type": "org"
+      "type": "org",
+      "need": "community"
     },
     {
       "name": "Ethical Design Network",
       "url": "https://ethicaldesignnetwork.com/",
       "description": "is a community for people interested in ethical design.",
-      "type": "org"
+      "type": "org",
+      "need": "community"
     }
   ], 
   "sustainability": [


### PR DESCRIPTION
The script has been updated to support two new resource fields: `need` and `iframe`. The `need` field determines the resource carpet design, while the `iframe` field determines whether the resource is opened as an iframe or as a new tab. 

Currently, only the resources in the ethics category have been manually updated with values for these fields. The script also processes resources without these fields, with the default `need` being set to `other` and the default `iframe` value set to `false`. 
